### PR TITLE
Hide dock agents in full-screen spaces

### DIFF
--- a/LilAgents/LilAgentsApp.swift
+++ b/LilAgents/LilAgentsApp.swift
@@ -144,12 +144,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func toggleChar1(_ sender: NSMenuItem) {
         guard let chars = controller?.characters, chars.count > 0 else { return }
         let char = chars[0]
-        if char.window.isVisible {
-            char.window.orderOut(nil)
-            char.queuePlayer.pause()
+        if char.isManuallyVisible {
+            char.setManuallyVisible(false)
             sender.state = .off
         } else {
-            char.window.orderFrontRegardless()
+            char.setManuallyVisible(true)
             sender.state = .on
         }
     }
@@ -157,12 +156,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func toggleChar2(_ sender: NSMenuItem) {
         guard let chars = controller?.characters, chars.count > 1 else { return }
         let char = chars[1]
-        if char.window.isVisible {
-            char.window.orderOut(nil)
-            char.queuePlayer.pause()
+        if char.isManuallyVisible {
+            char.setManuallyVisible(false)
             sender.state = .off
         } else {
-            char.window.orderFrontRegardless()
+            char.setManuallyVisible(true)
             sender.state = .on
         }
     }

--- a/LilAgents/LilAgentsController.swift
+++ b/LilAgents/LilAgentsController.swift
@@ -6,6 +6,7 @@ class LilAgentsController {
     var debugWindow: NSWindow?
     var pinnedScreenIndex: Int = -1
     private static let onboardingKey = "hasCompletedOnboarding"
+    private var isHiddenForEnvironment = false
 
     func start() {
         let char1 = WalkerCharacter(videoName: "walk-bruce-01")
@@ -77,7 +78,7 @@ class LilAgentsController {
         win.hasShadow = false
         win.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 10)
         win.ignoresMouseEvents = true
-        win.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        win.collectionBehavior = [.moveToActiveSpace, .stationary]
         win.orderOut(nil)
         debugWindow = win
     }
@@ -127,6 +128,11 @@ class LilAgentsController {
         return (dockX, dockWidth)
     }
 
+    private func dockAutohideEnabled() -> Bool {
+        let dockDefaults = UserDefaults(suiteName: "com.apple.dock")
+        return dockDefaults?.bool(forKey: "autohide") ?? false
+    }
+
     // MARK: - Display Link
 
     private func startDisplayLink() {
@@ -159,29 +165,51 @@ class LilAgentsController {
         return screen.visibleFrame.origin.y > screen.frame.origin.y
     }
 
+    private func shouldShowCharacters(on screen: NSScreen) -> Bool {
+        if screenHasDock(screen) {
+            return true
+        }
+
+        // With dock auto-hide enabled on the active desktop, the dock can still be
+        // present even though visibleFrame starts at the screen origin. In fullscreen
+        // spaces, both the dock and menu bar are absent, so visibleFrame matches frame.
+        let menuBarVisible = screen.visibleFrame.maxY < screen.frame.maxY
+        return dockAutohideEnabled() && screen == NSScreen.main && menuBarVisible
+    }
+
+    @discardableResult
+    private func updateEnvironmentVisibility(for screen: NSScreen) -> Bool {
+        let shouldShow = shouldShowCharacters(on: screen)
+        guard shouldShow != !isHiddenForEnvironment else { return shouldShow }
+
+        isHiddenForEnvironment = !shouldShow
+
+        if shouldShow {
+            characters.forEach { $0.showForEnvironmentIfNeeded() }
+        } else {
+            debugWindow?.orderOut(nil)
+            characters.forEach { $0.hideForEnvironment() }
+        }
+
+        return shouldShow
+    }
+
     func tick() {
         guard let screen = activeScreen else { return }
+        guard updateEnvironmentVisibility(for: screen) else { return }
 
         let screenWidth = screen.frame.width
         let dockX: CGFloat
         let dockWidth: CGFloat
         let dockTopY: CGFloat
 
-        if screenHasDock(screen) {
-            // Dock is on this screen — constrain to dock area
-            (dockX, dockWidth) = getDockIconArea(screenWidth: screenWidth)
-            dockTopY = screen.visibleFrame.origin.y
-        } else {
-            // No dock on this screen — use full screen width with small margin
-            let margin: CGFloat = 40.0
-            dockX = screen.frame.origin.x + margin
-            dockWidth = screenWidth - margin * 2
-            dockTopY = screen.frame.origin.y
-        }
+        // Dock is on this screen — constrain to dock area
+        (dockX, dockWidth) = getDockIconArea(screenWidth: screenWidth)
+        dockTopY = screen.visibleFrame.origin.y
 
         updateDebugLine(dockX: dockX, dockWidth: dockWidth, dockTopY: dockTopY)
 
-        let activeChars = characters.filter { $0.window.isVisible }
+        let activeChars = characters.filter { $0.window.isVisible && $0.isManuallyVisible }
 
         let now = CACurrentMediaTime()
         let anyWalking = activeChars.contains { $0.isWalking }

--- a/LilAgents/WalkerCharacter.swift
+++ b/LilAgents/WalkerCharacter.swift
@@ -54,6 +54,10 @@ class WalkerCharacter {
     var themeOverride: PopoverTheme?
     var isClaudeBusy: Bool { claudeSession?.isBusy ?? false }
     var thinkingBubbleWindow: NSWindow?
+    private(set) var isManuallyVisible = true
+    private var environmentHiddenAt: CFTimeInterval?
+    private var wasPopoverVisibleBeforeEnvironmentHide = false
+    private var wasBubbleVisibleBeforeEnvironmentHide = false
 
     init(videoName: String) {
         self.videoName = videoName
@@ -93,7 +97,7 @@ class WalkerCharacter {
         window.hasShadow = false
         window.level = .statusBar
         window.ignoresMouseEvents = false
-        window.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        window.collectionBehavior = [.moveToActiveSpace, .stationary]
 
         let hostView = CharacterContentView(frame: CGRect(x: 0, y: 0, width: displayWidth, height: displayHeight))
         hostView.character = self
@@ -103,6 +107,66 @@ class WalkerCharacter {
 
         window.contentView = hostView
         window.orderFrontRegardless()
+    }
+
+    // MARK: - Visibility
+
+    func setManuallyVisible(_ visible: Bool) {
+        isManuallyVisible = visible
+        if visible {
+            if environmentHiddenAt == nil {
+                window.orderFrontRegardless()
+            }
+        } else {
+            queuePlayer.pause()
+            window.orderOut(nil)
+            popoverWindow?.orderOut(nil)
+            thinkingBubbleWindow?.orderOut(nil)
+        }
+    }
+
+    func hideForEnvironment() {
+        guard environmentHiddenAt == nil else { return }
+
+        environmentHiddenAt = CACurrentMediaTime()
+        wasPopoverVisibleBeforeEnvironmentHide = popoverWindow?.isVisible ?? false
+        wasBubbleVisibleBeforeEnvironmentHide = thinkingBubbleWindow?.isVisible ?? false
+
+        queuePlayer.pause()
+        window.orderOut(nil)
+        popoverWindow?.orderOut(nil)
+        thinkingBubbleWindow?.orderOut(nil)
+    }
+
+    func showForEnvironmentIfNeeded() {
+        guard let hiddenAt = environmentHiddenAt else { return }
+
+        let hiddenDuration = CACurrentMediaTime() - hiddenAt
+        environmentHiddenAt = nil
+        walkStartTime += hiddenDuration
+        pauseEndTime += hiddenDuration
+        completionBubbleExpiry += hiddenDuration
+        lastPhraseUpdate += hiddenDuration
+
+        guard isManuallyVisible else { return }
+
+        window.orderFrontRegardless()
+        if isWalking {
+            queuePlayer.play()
+        }
+
+        if isIdleForPopover && wasPopoverVisibleBeforeEnvironmentHide {
+            updatePopoverPosition()
+            popoverWindow?.orderFrontRegardless()
+            popoverWindow?.makeKey()
+            if let terminal = terminalView {
+                popoverWindow?.makeFirstResponder(terminal.inputField)
+            }
+        }
+
+        if wasBubbleVisibleBeforeEnvironmentHide {
+            updateThinkingBubble()
+        }
     }
 
     // MARK: - Click Handling & Popover
@@ -293,7 +357,7 @@ class WalkerCharacter {
         win.backgroundColor = .clear
         win.hasShadow = true
         win.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 10)
-        win.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        win.collectionBehavior = [.moveToActiveSpace, .stationary]
         let brightness = t.popoverBg.redComponent * 0.299 + t.popoverBg.greenComponent * 0.587 + t.popoverBg.blueComponent * 0.114
         win.appearance = NSAppearance(named: brightness < 0.5 ? .darkAqua : .aqua)
 
@@ -553,7 +617,7 @@ class WalkerCharacter {
         win.hasShadow = true
         win.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue + 5)
         win.ignoresMouseEvents = true
-        win.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        win.collectionBehavior = [.moveToActiveSpace, .stationary]
 
         let container = NSView(frame: NSRect(x: 0, y: 0, width: w, height: h))
         container.wantsLayer = true


### PR DESCRIPTION
## Summary
- stop character, popover, and bubble windows from joining all Spaces
- hide the agents when the active screen does not have a usable dock context
- preserve manual menu visibility state while full-screen spaces are active

## Testing
- xcodebuild -project lil-agents.xcodeproj -scheme LilAgents -configuration Debug build
- verified locally that the agents no longer appear over full-screen video playback