### PR TITLE
fix: preserve assistant responses in chat history

### DIFF
--- a/LilAgents/ClaudeSession.swift
+++ b/LilAgents/ClaudeSession.swift
@@ -8,6 +8,7 @@ class ClaudeSession {
     private var lineBuffer = ""
     private(set) var isRunning = false
     private(set) var isBusy = false  // true between send() and result
+    private var currentStreamingResponse = ""
     private static var claudePath: String?
     private static var shellEnvironment: [String: String]?
 
@@ -262,6 +263,7 @@ class ClaudeSession {
                 for block in content {
                     let blockType = block["type"] as? String ?? ""
                     if blockType == "text", let text = block["text"] as? String {
+                        currentStreamingResponse += text
                         onText?(text)
                     } else if blockType == "tool_use" {
                         let toolName = block["name"] as? String ?? "Tool"
@@ -304,9 +306,13 @@ class ClaudeSession {
 
         case "result":
             isBusy = false
-            if let result = json["result"] as? String, !result.isEmpty {
+            let responseText = currentStreamingResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !responseText.isEmpty {
+                history.append(Message(role: .assistant, text: responseText))
+            } else if let result = json["result"] as? String, !result.isEmpty {
                 history.append(Message(role: .assistant, text: result))
             }
+            currentStreamingResponse = ""
             onTurnComplete?()
 
         default:


### PR DESCRIPTION
## Summary
- Assistant responses from Claude CLI were lost when the chat popover closed and reopened
- Streaming text was displayed in real-time but never saved to session history
- `replayHistory()` only showed user messages, not Claude's responses

## Root Cause
Claude CLI sends responses as streaming `"assistant"` type messages, but the final `"result"` type message has an empty `"result"` field. The history was only populated from `result.result`, so responses were never persisted.

## Fix
- Accumulate streaming text in `currentStreamingResponse` during assistant messages
- Save accumulated text to history when the turn completes (`"result"` event)
- Reset accumulator for the next turn

## Test plan
- [x] Send a message, receive response
- [x] Close popover by clicking elsewhere
- [x] Reopen popover - both user message and assistant response are preserved
- [x] Send multiple messages - all history entries persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)