### PR TITLE
fix: strip CLAUDECODE env var before launching claude subprocess

### DIFF
--- a/LilAgents/ClaudeSession.swift
+++ b/LilAgents/ClaudeSession.swift
@@ -57,7 +57,9 @@ class ClaudeSession: AgentSession {
             "--dangerously-skip-permissions"
         ]
         proc.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
-        proc.environment = ShellEnvironment.processEnvironment()
+        var env = ShellEnvironment.processEnvironment()
+        env.removeValue(forKey: "CLAUDECODE")
+        proc.environment = env
 
         let inPipe = Pipe()
         let outPipe = Pipe()


### PR DESCRIPTION
## Problem

When lil-agents is launched from inside an existing Claude Code session (e.g. via a terminal where `CLAUDECODE` is set), the app fails silently — Claude never replies.

The root cause is two-layered:

1. `ShellEnvironment.processEnvironment()` runs `zsh -l -i` to capture the user's full login shell environment, which includes the `CLAUDECODE` variable set by the parent session.
2. This environment is passed directly to the `claude` subprocess, which triggers Claude Code's built-in nested-session guard:
   ```
   Error: Claude Code cannot be launched inside another Claude Code session.
   Nested sessions share runtime resources and will crash all active sessions.
   ```

## Fix

One line in `launchProcess()` — remove `CLAUDECODE` from the environment dict before handing it to the subprocess:

```swift
var env = ShellEnvironment.processEnvironment()
env.removeValue(forKey: "CLAUDECODE")
proc.environment = env
```

## Reproduction

1. Open a terminal with an active Claude Code session (or any shell where `CLAUDECODE` is set)
2. Launch lil-agents from that environment
3. Click the character and send a message → no response

With this fix, the nested-session check no longer fires regardless of how lil-agents is launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)