### PR TITLE
fix: characters disappear when clicking secondary display

### DIFF
--- a/LilAgents/LilAgentsController.swift
+++ b/LilAgents/LilAgentsController.swift
@@ -156,7 +156,19 @@ class LilAgentsController {
         if pinnedScreenIndex >= 0, pinnedScreenIndex < NSScreen.screens.count {
             return NSScreen.screens[pinnedScreenIndex]
         }
-        return NSScreen.main
+        // Prefer the screen that currently shows the dock (bottom inset in visibleFrame).
+        // NSScreen.main changes with keyboard focus and must NOT be used here — clicking a
+        // secondary display switches NSScreen.main to that display, causing characters on
+        // the dock screen to be incorrectly hidden.
+        if let dockScreen = NSScreen.screens.first(where: { screenHasDock($0) }) {
+            return dockScreen
+        }
+        // Dock is auto-hidden: fall back to the primary display, identified as the screen
+        // whose menu bar reserves space at the top (visibleFrame.maxY < frame.maxY).
+        if let primaryScreen = NSScreen.screens.first(where: { $0.visibleFrame.maxY < $0.frame.maxY }) {
+            return primaryScreen
+        }
+        return NSScreen.screens.first
     }
 
     /// The dock lives on the screen where visibleFrame.origin.y > frame.origin.y (bottom dock)
@@ -174,7 +186,7 @@ class LilAgentsController {
         // present even though visibleFrame starts at the screen origin. In fullscreen
         // spaces, both the dock and menu bar are absent, so visibleFrame matches frame.
         let menuBarVisible = screen.visibleFrame.maxY < screen.frame.maxY
-        return dockAutohideEnabled() && screen == NSScreen.main && menuBarVisible
+        return dockAutohideEnabled() && menuBarVisible
     }
 
     @discardableResult


### PR DESCRIPTION
## Problem                                                                                      
  When an external display is connected, clicking anywhere on the secondary
  screen causes the characters on the main screen to disappear.                                   
                                                                                                  
## Root Cause
  `NSScreen.main` returns the screen with current keyboard focus, not the                         
  screen where the Dock lives. Clicking the secondary display switches   
  `NSScreen.main` to that screen. Since the secondary screen has no Dock,                         
  `shouldShowCharacters()` returns false and the characters are hidden.                           
                                                                                                  
## Fix                                                                                          
  - `activeScreen` now finds the dock screen directly via `screenHasDock()`,                      
    rather than relying on `NSScreen.main`                                  
  - Falls back to the menu-bar screen for auto-hide dock setups                                   
  - Removed the `screen == NSScreen.main` guard from `shouldShowCharacters()`                     
    since `activeScreen` now always resolves to the correct screen                                
                                                                                                  
## Testing                                                
  Tested with one external display connected. Characters remain visible on                        
  the dock screen while interacting with the secondary display.