### PR TITLE
fix: show dock agents when dock is on the side

### DIFF
--- a/LilAgents/DockVisibility.swift
+++ b/LilAgents/DockVisibility.swift
@@ -1,0 +1,29 @@
+import CoreGraphics
+
+enum DockVisibility {
+    static func screenHasVisibleDockReservedArea(
+        screenFrame: CGRect,
+        visibleFrame: CGRect
+    ) -> Bool {
+        visibleFrame.minX > screenFrame.minX ||
+        visibleFrame.minY > screenFrame.minY ||
+        visibleFrame.maxX < screenFrame.maxX
+    }
+
+    static func shouldShowCharacters(
+        screenFrame: CGRect,
+        visibleFrame: CGRect,
+        isMainScreen: Bool,
+        dockAutohideEnabled: Bool
+    ) -> Bool {
+        if screenHasVisibleDockReservedArea(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame
+        ) {
+            return true
+        }
+
+        let menuBarVisible = visibleFrame.maxY < screenFrame.maxY
+        return dockAutohideEnabled && isMainScreen && menuBarVisible
+    }
+}

--- a/LilAgents/LilAgentsController.swift
+++ b/LilAgents/LilAgentsController.swift
@@ -159,22 +159,13 @@ class LilAgentsController {
         return NSScreen.main
     }
 
-    /// The dock lives on the screen where visibleFrame.origin.y > frame.origin.y (bottom dock)
-    /// On screens without the dock, visibleFrame.origin.y == frame.origin.y
-    private func screenHasDock(_ screen: NSScreen) -> Bool {
-        return screen.visibleFrame.origin.y > screen.frame.origin.y
-    }
-
     private func shouldShowCharacters(on screen: NSScreen) -> Bool {
-        if screenHasDock(screen) {
-            return true
-        }
-
-        // With dock auto-hide enabled on the active desktop, the dock can still be
-        // present even though visibleFrame starts at the screen origin. In fullscreen
-        // spaces, both the dock and menu bar are absent, so visibleFrame matches frame.
-        let menuBarVisible = screen.visibleFrame.maxY < screen.frame.maxY
-        return dockAutohideEnabled() && screen == NSScreen.main && menuBarVisible
+        DockVisibility.shouldShowCharacters(
+            screenFrame: screen.frame,
+            visibleFrame: screen.visibleFrame,
+            isMainScreen: screen == NSScreen.main,
+            dockAutohideEnabled: dockAutohideEnabled()
+        )
     }
 
     @discardableResult

--- a/Tests/DockVisibilityTests.swift
+++ b/Tests/DockVisibilityTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import CoreGraphics
+
+func runDockVisibilityTests() {
+    func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        if !condition() {
+            fputs("FAIL: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+
+    let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+
+    expect(
+        DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: CGRect(x: 0, y: 64, width: 1440, height: 811),
+            isMainScreen: true,
+            dockAutohideEnabled: false
+        ),
+        "shows characters when the bottom dock reserves screen space"
+    )
+
+    expect(
+        DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: CGRect(x: 96, y: 0, width: 1344, height: 875),
+            isMainScreen: true,
+            dockAutohideEnabled: false
+        ),
+        "shows characters when the dock is pinned to the left edge"
+    )
+
+    expect(
+        DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: CGRect(x: 0, y: 0, width: 1344, height: 875),
+            isMainScreen: true,
+            dockAutohideEnabled: false
+        ),
+        "shows characters when the dock is pinned to the right edge"
+    )
+
+    expect(
+        !DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: screenFrame,
+            isMainScreen: true,
+            dockAutohideEnabled: false
+        ),
+        "hides characters in fullscreen spaces where neither dock nor menu bar is visible"
+    )
+
+    expect(
+        DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            isMainScreen: true,
+            dockAutohideEnabled: true
+        ),
+        "shows characters on the main screen when the dock auto-hides but the menu bar is visible"
+    )
+
+    expect(
+        !DockVisibility.shouldShowCharacters(
+            screenFrame: screenFrame,
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 875),
+            isMainScreen: false,
+            dockAutohideEnabled: true
+        ),
+        "keeps characters hidden on non-main screens when only the menu bar is visible"
+    )
+
+    print("DockVisibility tests passed")
+}

--- a/Tests/main.swift
+++ b/Tests/main.swift
@@ -1,0 +1,1 @@
+runDockVisibilityTests()

--- a/lil-agents.xcodeproj/project.pbxproj
+++ b/lil-agents.xcodeproj/project.pbxproj
@@ -22,8 +22,9 @@
 		A10000010000000000000031 /* AgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000030 /* AgentSession.swift */; };
 		A10000010000000000000032 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000031 /* ShellEnvironment.swift */; };
 		A10000010000000000000033 /* CodexSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000032 /* CodexSession.swift */; };
-		A10000010000000000000034 /* CopilotSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000033 /* CopilotSession.swift */; };
-		A10000010000000000000035 /* GeminiSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000034 /* GeminiSession.swift */; };
+			A10000010000000000000034 /* CopilotSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000033 /* CopilotSession.swift */; };
+			A10000010000000000000035 /* GeminiSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000034 /* GeminiSession.swift */; };
+			A10000010000000000000036 /* DockVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000035 /* DockVisibility.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,10 +43,11 @@
 		A10000020000000000000025 /* LilAgentsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LilAgentsController.swift; sourceTree = "<group>"; };
 		A10000020000000000000030 /* AgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSession.swift; sourceTree = "<group>"; };
 		A10000020000000000000031 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
-		A10000020000000000000032 /* CodexSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexSession.swift; sourceTree = "<group>"; };
-		A10000020000000000000033 /* CopilotSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotSession.swift; sourceTree = "<group>"; };
-		A10000020000000000000034 /* GeminiSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiSession.swift; sourceTree = "<group>"; };
-		A10000030000000000000001 /* lil agents.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "lil agents.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+			A10000020000000000000032 /* CodexSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexSession.swift; sourceTree = "<group>"; };
+			A10000020000000000000033 /* CopilotSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotSession.swift; sourceTree = "<group>"; };
+			A10000020000000000000034 /* GeminiSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiSession.swift; sourceTree = "<group>"; };
+			A10000020000000000000035 /* DockVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockVisibility.swift; sourceTree = "<group>"; };
+			A10000030000000000000001 /* lil agents.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "lil agents.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,12 +79,13 @@
 				A10000020000000000000030 /* AgentSession.swift */,
 				A10000020000000000000031 /* ShellEnvironment.swift */,
 				A10000020000000000000022 /* ClaudeSession.swift */,
-				A10000020000000000000032 /* CodexSession.swift */,
-				A10000020000000000000033 /* CopilotSession.swift */,
-				A10000020000000000000034 /* GeminiSession.swift */,
-				A10000020000000000000023 /* TerminalView.swift */,
-				A10000020000000000000024 /* WalkerCharacter.swift */,
-				A10000020000000000000025 /* LilAgentsController.swift */,
+					A10000020000000000000032 /* CodexSession.swift */,
+					A10000020000000000000033 /* CopilotSession.swift */,
+					A10000020000000000000034 /* GeminiSession.swift */,
+					A10000020000000000000035 /* DockVisibility.swift */,
+					A10000020000000000000023 /* TerminalView.swift */,
+					A10000020000000000000024 /* WalkerCharacter.swift */,
+					A10000020000000000000025 /* LilAgentsController.swift */,
 				A10000020000000000000002 /* walk-bruce-01.mov */,
 				A10000020000000000000005 /* walk-jazz-01.mov */,
 				A10000020000000000000007 /* Assets.xcassets */,
@@ -185,12 +188,13 @@
 				A10000010000000000000031 /* AgentSession.swift in Sources */,
 				A10000010000000000000032 /* ShellEnvironment.swift in Sources */,
 				A10000010000000000000022 /* ClaudeSession.swift in Sources */,
-				A10000010000000000000033 /* CodexSession.swift in Sources */,
-				A10000010000000000000034 /* CopilotSession.swift in Sources */,
-				A10000010000000000000035 /* GeminiSession.swift in Sources */,
-				A10000010000000000000023 /* TerminalView.swift in Sources */,
-				A10000010000000000000024 /* WalkerCharacter.swift in Sources */,
-				A10000010000000000000025 /* LilAgentsController.swift in Sources */,
+					A10000010000000000000033 /* CodexSession.swift in Sources */,
+					A10000010000000000000034 /* CopilotSession.swift in Sources */,
+					A10000010000000000000035 /* GeminiSession.swift in Sources */,
+					A10000010000000000000036 /* DockVisibility.swift in Sources */,
+					A10000010000000000000023 /* TerminalView.swift in Sources */,
+					A10000010000000000000024 /* WalkerCharacter.swift in Sources */,
+					A10000010000000000000025 /* LilAgentsController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

  This fixes a visibility regression where lil agents would only appear when the macOS
  Dock was at the bottom.

  When the Dock was pinned to the left or right, the app incorrectly treated that screen
  as if no Dock was present, so only the menu bar item appeared and the dock agents
  stayed hidden.

  ## What changed

  - extract Dock visibility checks into a dedicated `DockVisibility` helper
  - treat left, right, and bottom Dock reserved areas as valid visible Dock states
  - keep the existing fullscreen and auto-hide behavior intact
  - add a small regression test script covering:
    - bottom Dock
    - left Dock
    - right Dock
    - fullscreen space
    - auto-hidden Dock on main screen

  ## Test Plan

  - [x] Run the Dock visibility regression script:
    - `swiftc -module-cache-path /tmp/swift-module-cache LilAgents/DockVisibility.swift
  Tests/DockVisibilityTests.swift Tests/main.swift -o /tmp/dock-visibility-tests && /tmp/
  dock-visibility-tests`
  - [x] Build the app:
    - `xcodebuild -project lil-agents.xcodeproj -scheme LilAgents -configuration Release
  -derivedDataPath /tmp/lil-agents-derived -clonedSourcePackagesDirPath /tmp/lil-agents-
  sourcepackages build`
  - [x] Manually verify the app now shows dock agents on a Mac with the Dock pinned to
  the left