### PR TITLE
Smooth dock-dodging animation for auto-hide dock

### DIFF
--- a/LilAgents/Assets.xcassets/bruce-hang.imageset/Contents.json
+++ b/LilAgents/Assets.xcassets/bruce-hang.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "bruce-hang.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/LilAgents/LilAgentsController.swift
+++ b/LilAgents/LilAgentsController.swift
@@ -8,6 +8,51 @@ class LilAgentsController {
     private static let onboardingKey = "hasCompletedOnboarding"
     private var isHiddenForEnvironment = false
 
+    // MARK: - Auto-hide Dock Dodging
+
+    /// Whether the cursor is currently in the dock trigger zone (bottom 5px of screen).
+    private var mouseInDockZone = false
+
+    /// Smoothed Y offset for character position when dock auto-hides.
+    private var smoothedDockOffset: CGFloat = 0
+    private static let dockRiseFactor: CGFloat = 0.05   // slow rise to match dock's smooth reveal
+    private static let dockDropFactor: CGFloat = 0.12    // faster drop (dock hides quicker)
+
+    /// Timestamp when cursor entered dock zone — used to add a small delay before rising.
+    private var dockZoneEntryTime: CFTimeInterval = 0
+    private static let dockRiseDelay: CFTimeInterval = 0.3  // match dock's initial hesitation
+
+    /// Estimated dock height from the tile size preference (~tileSize + 22px padding)
+    private var estimatedDockHeight: CGFloat {
+        let tileSize = CGFloat(UserDefaults(suiteName: "com.apple.dock")?.double(forKey: "tilesize") ?? 48)
+        return tileSize + 22
+    }
+
+    /// Event monitors for mouse movement — fires only when the cursor actually moves.
+    private var dockMouseMonitor: Any?
+    private var dockLocalMouseMonitor: Any?
+
+    private func setupDockMouseMonitor() {
+        dockMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            self?.updateDockZoneFromMouse()
+        }
+        dockLocalMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            self?.updateDockZoneFromMouse()
+            return event
+        }
+    }
+
+    private func updateDockZoneFromMouse() {
+        guard dockAutohideEnabled(), let screen = activeScreen else { return }
+        let mouseLocation = NSEvent.mouseLocation
+        let screenBottom = screen.frame.origin.y
+        let wasInZone = mouseInDockZone
+        mouseInDockZone = mouseLocation.y - screenBottom < estimatedDockHeight
+        if mouseInDockZone && !wasInZone {
+            dockZoneEntryTime = CACurrentMediaTime()
+        }
+    }
+
     func start() {
         let char1 = WalkerCharacter(videoName: "walk-bruce-01", name: "Bruce")
         let char2 = WalkerCharacter(videoName: "walk-jazz-01", name: "Jazz")
@@ -54,6 +99,7 @@ class LilAgentsController {
         characters.forEach { $0.controller = self }
 
         setupDebugLine()
+        setupDockMouseMonitor()
         startDisplayLink()
 
         if !UserDefaults.standard.bool(forKey: Self.onboardingKey) {
@@ -220,11 +266,23 @@ class LilAgentsController {
         let screenWidth = screen.frame.width
         let dockX: CGFloat
         let dockWidth: CGFloat
-        let dockTopY: CGFloat
+        var dockTopY: CGFloat
 
         // Dock is on this screen — constrain to dock area
         (dockX, dockWidth) = getDockIconArea(screenWidth: screenWidth)
         dockTopY = screen.visibleFrame.origin.y
+
+        // When dock auto-hides, smoothly move characters up when cursor
+        // enters the dock trigger zone so they don't overlap the dock.
+        if !screenHasDock(screen) && dockAutohideEnabled() {
+            let wantRise = mouseInDockZone && (CACurrentMediaTime() - dockZoneEntryTime >= Self.dockRiseDelay)
+            let targetOffset = wantRise ? estimatedDockHeight : 0
+            let factor = targetOffset > smoothedDockOffset ? Self.dockRiseFactor : Self.dockDropFactor
+            smoothedDockOffset += (targetOffset - smoothedDockOffset) * factor
+            dockTopY += smoothedDockOffset
+        } else {
+            smoothedDockOffset = 0
+        }
 
         updateDebugLine(dockX: dockX, dockWidth: dockWidth, dockTopY: dockTopY)
 
@@ -251,6 +309,12 @@ class LilAgentsController {
     deinit {
         if let displayLink = displayLink {
             CVDisplayLinkStop(displayLink)
+        }
+        if let monitor = dockMouseMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if let monitor = dockLocalMouseMonitor {
+            NSEvent.removeMonitor(monitor)
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements event-driven dock dodging so characters smoothly animate out of the way when the macOS auto-hide dock appears. This builds on the approach from #18 with several enhancements:

- **Expanded trigger zone**: Detects cursor in the full estimated dock height area (tileSize + 22px) instead of just the bottom 5px, so characters begin moving as the dock starts to rise
- **Asymmetric smoothing**: Uses a slower rise factor (0.05) to match the dock's gradual reveal animation, and a faster drop factor (0.12) for when the dock hides
- **Rise delay**: Adds a 0.3s delay before characters start rising, matching the dock's initial hesitation before it appears
- **Proper event forwarding**: Local mouse monitor returns the event instead of `nil` to avoid swallowing mouse events

### How it works

- Uses `NSEvent.addGlobalMonitorForEvents` + local monitor to track cursor movement (event-driven, no polling)
- When cursor enters the dock zone and auto-hide is enabled, smoothly interpolates character Y position upward
- Characters animate back down when cursor leaves the zone
- Both monitors are properly cleaned up in `deinit`

## Test plan

- [ ] Enable "Automatically hide and show the Dock" in System Settings
- [ ] Launch the app and move cursor to screen bottom edge
- [ ] Verify characters smoothly rise **in sync** with the dock appearing
- [ ] Move cursor away from bottom — verify characters drop back down smoothly
- [ ] Disable auto-hide dock — verify characters behave normally on the visible dock
- [ ] Test with different dock tile sizes

Ref: #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)