### PR TITLE
feat: add Homebrew Cask installation support

### DIFF
--- a/Casks/lil-agents.rb
+++ b/Casks/lil-agents.rb
@@ -1,0 +1,19 @@
+cask "lil-agents" do
+  version "1.2.2"
+  sha256 "a4cf7d9955ffb3881c6050505a9aedd91dd553952dc3e53aa00e4eb52485ea95"
+
+  url "https://github.com/ryanstephen/lil-agents/releases/download/v#{version}/LilAgents-v#{version}.zip",
+      verified: "github.com/ryanstephen/lil-agents/"
+  name "lil agents"
+  desc "Tiny AI companions that live on your macOS dock"
+  homepage "https://lilagents.xyz"
+
+  depends_on macos: ">= :sonoma"
+
+  app "lil agents.app"
+
+  zap trash: [
+    "~/Library/Preferences/xyz.lilagents.LilAgents.plist",
+    "~/Library/Caches/xyz.lilagents.LilAgents",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Supports **Claude Code**, **OpenAI Codex**, **GitHub Copilot**, and **Google Gem
 
 **[Download for macOS](https://lilagents.xyz)** · [Website](https://lilagents.xyz)
 
+## install
+
+### Homebrew (recommended)
+
+```bash
+brew tap ryanstephen/lil-agents
+brew install --cask lil-agents
+```
+
+### Direct download
+
+Download the latest release from [lilagents.xyz](https://lilagents.xyz).
+
 ## features
 
 - Animated characters rendered from transparent HEVC video

--- a/homebrew/lil-agents.rb
+++ b/homebrew/lil-agents.rb
@@ -1,0 +1,19 @@
+cask "lil-agents" do
+  version "1.2.2"
+  sha256 "a4cf7d9955ffb3881c6050505a9aedd91dd553952dc3e53aa00e4eb52485ea95"
+
+  url "https://github.com/ryanstephen/lil-agents/releases/download/v#{version}/LilAgents-v#{version}.zip",
+      verified: "github.com/ryanstephen/lil-agents/"
+  name "lil agents"
+  desc "Tiny AI companions that live on your macOS dock"
+  homepage "https://lilagents.xyz"
+
+  depends_on macos: ">= :sonoma"
+
+  app "lil agents.app"
+
+  zap trash: [
+    "~/Library/Preferences/xyz.lilagents.LilAgents.plist",
+    "~/Library/Caches/xyz.lilagents.LilAgents",
+  ]
+end


### PR DESCRIPTION
## Summary
- Add Homebrew Cask definition (`Casks/lil-agents.rb`) for project-owned tap
- Add official homebrew-cask submission file (`homebrew/lil-agents.rb`) as reference
- Update README with Homebrew installation instructions

## Project-Owned Tap Setup

To enable `brew tap ryanstephen/lil-agents`, create a new repo named **`homebrew-lil-agents`** on the `ryanstephen` GitHub account and copy `Casks/lil-agents.rb` into it:

```
homebrew-lil-agents/
  └── Casks/
      └── lil-agents.rb
```

Users can then install via:
```bash
brew tap ryanstephen/lil-agents
brew install --cask lil-agents
```

## Official homebrew-cask Submission

The `homebrew/lil-agents.rb` file is ready to submit as a PR to `homebrew/homebrew-cask`. Once approved, users can install with just:
```bash
brew install --cask lil-agents
```

At that point, the project-owned tap becomes optional and can be removed.

## Test plan
- [x] SHA256 verified against v1.2.2 release zip
- [x] Ruby syntax check passed
- [x] Run `brew audit --cask` once in a proper tap context
- [x] Confirm README renders correctly with new install section