### PR TITLE
fix(claude): remove --dangerously-skip-permissions flag

### DIFF
--- a/LilAgents/ClaudeSession.swift
+++ b/LilAgents/ClaudeSession.swift
@@ -55,8 +55,7 @@ class ClaudeSession: AgentSession {
             "-p",
             "--output-format", "stream-json",
             "--input-format", "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions"
+            "--verbose"
         ]
         proc.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
         proc.environment = ShellEnvironment.processEnvironment()


### PR DESCRIPTION
## Summary

- Removes the `--dangerously-skip-permissions` flag from the Claude CLI invocation in `ClaudeSession.swift`
- Claude Code now runs with its standard permission system, prompting the user before executing file writes, shell commands, or other potentially destructive actions
- No other behaviour is changed — streaming JSON I/O, session lifecycle, and history handling are all unaffected

## Motivation

The flag was silently bypassing all of Claude's built-in safety guardrails. A user interacting via the lil agents chat UI had no indication that Claude could write files or run shell commands without any confirmation. Restoring the default permission flow gives users visibility and control over what the agent does on their machine.

## Test plan

- [ ] Build and run the app in Xcode
- [ ] Open the Claude chat popover and send a prompt that triggers a tool use (e.g. "create a file called test.txt")
- [ ] Confirm that Claude now shows a permission prompt / pauses for confirmation instead of executing silently
- [ ] Confirm normal conversation (no tool use) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)